### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Digest/HMAC.pm6
+++ b/lib/Digest/HMAC.pm6
@@ -1,4 +1,4 @@
-module Digest::HMAC;
+unit module Digest::HMAC;
 
 our sub hmac($key is copy, $message is copy, &hash, $blocksize = 64) is export {
     $key = $key.encode('ascii') unless $key ~~ Blob;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.